### PR TITLE
Improved legend for logistic regression

### DIFF
--- a/ex2.Logistic_Regression/mlclass-ex2/ex2.m
+++ b/ex2.Logistic_Regression/mlclass-ex2/ex2.m
@@ -101,7 +101,7 @@ xlabel('Exam 1 score')
 ylabel('Exam 2 score')
 
 % Specified in plot order
-legend('Admitted', 'Not admitted')
+legend('Admitted', 'Not admitted', 'Decision Boundary')
 hold off;
 
 fprintf('\nProgram paused. Press enter to continue.\n');


### PR DESCRIPTION
The "Decision Boundary" legend was missing from the logistic regression experiment because the legend was reset in the ex2.m file, and has been added to this PR

### Before

<img width="672" alt="Screen Shot 2022-04-21 at 08 50 29" src="https://user-images.githubusercontent.com/51821219/164350243-09029805-cd43-420a-bd93-25d6af22d255.png">

### After

<img width="672" alt="Screen Shot 2022-04-21 at 08 50 47" src="https://user-images.githubusercontent.com/51821219/164350265-4294b625-3c5e-413b-91e6-22cc8ad52535.png">

